### PR TITLE
Add context identifier

### DIFF
--- a/rules/no-only-tests.js
+++ b/rules/no-only-tests.js
@@ -1,5 +1,5 @@
 module.exports = function(context) {
-  var regex = /^(describe|it)$/;
+  var regex = /^(describe|it|context)$/;
 
   return {
     Identifier: function(node) {


### PR DESCRIPTION
The rule should catch `context.only`, which is valid BDD in Mocha https://mochajs.org/#bdd