### PR TITLE
Add rule for catching '.only' blocks for 'fixture'

### DIFF
--- a/rules/no-only-tests.js
+++ b/rules/no-only-tests.js
@@ -18,7 +18,7 @@ module.exports = {
   },
 
   create(context) {
-    const regex = /^(describe|it|context|test|tape)$/;
+    const regex = /^(describe|it|context|test|tape|fixture)$/;
 
     return {
       Identifier: function(node) {

--- a/tests.js
+++ b/tests.js
@@ -31,6 +31,9 @@ ruleTester.run('no-only-tests', rules['no-only-tests'], {
   }, {
     code: 'tape.only("A tape", function() {});',
     errors: [{message: 'tape.only not permitted'}]
+  }, {
+    code: 'fixture.only("A fixture", function() {});',
+    errors: [{message: 'fixture.only not permitted'}]
   }]
 });
 


### PR DESCRIPTION
I'd like to have the `fixture` functions tested to the `.only` block as well. We're using [TestCafe](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#fixtures) that provides such a function.