### PR TITLE
Add support for defining 2 levels deep in blocks (ie. `ava.default`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
+# v2.4.0
+
+ * Add support for defining 2 levels deep in blocks (ie. `ava.default`)
+
 # v2.3.1
 
  * Bump js-yaml from 3.13.0 to 3.13.1 due to security vulnerability - #11
- 
+
 # v2.3.0
 
  * Allow test block names to be specified in options - #10

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-no-only-tests",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "ESLint rule for .only blocks in mocha tests",
   "keywords": [
     "eslint",

--- a/rules/no-only-tests.js
+++ b/rules/no-only-tests.js
@@ -49,15 +49,28 @@ module.exports = {
 
     return {
       Identifier(node) {
-        if (
-          focus.indexOf(node.name) != -1 &&
-          node.parent &&
-          node.parent.object &&
-          block.indexOf(node.parent.object.name) != -1
-        ) {
-          context.report(node, node.parent.object.name + '.' + node.name + ' not permitted');
+        var parentObject = node.parent && node.parent.object;
+        if (parentObject == null) return;
+        if (focus.indexOf(node.name) === -1) return;
+
+        var parentName = parentObject.name;
+
+        if (parentName != null && block.indexOf(parentName) != -1) {
+          context.report(node, parentName + '.' + node.name + ' not permitted');
+        }
+
+        var parentParentName = dotName(parentObject);
+
+        if (parentParentName != null && block.indexOf(parentParentName) != -1) {
+          context.report(node, parentParentName + '.' + node.name + ' not permitted');
         }
       },
     };
   },
 };
+
+function dotName(object) {
+  if (object.property && object.property.name && object.object && object.object.name)
+    return object.object.name + '.' + object.property.name;
+  return null;
+}

--- a/tests.js
+++ b/tests.js
@@ -22,39 +22,54 @@ ruleTester.run('no-only-tests', rules['no-only-tests'], {
     {
       options: [{focus: ['focus']}],
       code: 'test.only("Options will exclude this from being caught", function() {});',
-    }
+    },
   ],
 
-  invalid: [{
-    code: 'describe.only("Some describe block", function() {});',
-    errors: [{message: 'describe.only not permitted'}]
-  }, {
-    code: 'it.only("Some assertion", function() {});',
-    errors: [{message: 'it.only not permitted'}]
-  }, {
-    code: 'context.only("Some context", function() {});',
-    errors: [{message: 'context.only not permitted'}]
-  }, {
-    code: 'test.only("Some test", function() {});',
-    errors: [{message: 'test.only not permitted'}]
-  }, {
-    code: 'tape.only("A tape", function() {});',
-    errors: [{message: 'tape.only not permitted'}]
-  }, {
-    code: 'fixture.only("A fixture", function() {});',
-    errors: [{message: 'fixture.only not permitted'}]
-  }, {
-    code: 'serial.only("A serial test", function() {});',
-    errors: [{message: 'serial.only not permitted'}]
-  }, {
-    options: [{block: ['obscureTestBlock']}],
-    code: 'obscureTestBlock.only("An obscure testing library test", function() {});',
-    errors: [{message: 'obscureTestBlock.only not permitted'}]
-  }, {
-    options: [{focus: ['focus']}],
-    code: 'test.focus("An alternative focus function", function() {});',
-    errors: [{message: 'test.focus not permitted'}]
-  }]
+  invalid: [
+    {
+      code: 'describe.only("Some describe block", function() {});',
+      errors: [{message: 'describe.only not permitted'}],
+    },
+    {
+      code: 'it.only("Some assertion", function() {});',
+      errors: [{message: 'it.only not permitted'}],
+    },
+    {
+      code: 'context.only("Some context", function() {});',
+      errors: [{message: 'context.only not permitted'}],
+    },
+    {
+      code: 'test.only("Some test", function() {});',
+      errors: [{message: 'test.only not permitted'}],
+    },
+    {
+      code: 'tape.only("A tape", function() {});',
+      errors: [{message: 'tape.only not permitted'}],
+    },
+    {
+      code: 'fixture.only("A fixture", function() {});',
+      errors: [{message: 'fixture.only not permitted'}],
+    },
+    {
+      code: 'serial.only("A serial test", function() {});',
+      errors: [{message: 'serial.only not permitted'}],
+    },
+    {
+      options: [{block: ['obscureTestBlock']}],
+      code: 'obscureTestBlock.only("An obscure testing library test", function() {});',
+      errors: [{message: 'obscureTestBlock.only not permitted'}],
+    },
+    {
+      options: [{block: ['ava.default']}],
+      code: 'ava.default.only("Block with dot", function() {});',
+      errors: [{message: 'ava.default.only not permitted'}],
+    },
+    {
+      options: [{focus: ['focus']}],
+      code: 'test.focus("An alternative focus function", function() {});',
+      errors: [{message: 'test.focus not permitted'}],
+    },
+  ],
 });
 
 console.log('Tests completed successfully');


### PR DESCRIPTION
```js
  rules: {
    'no-only-tests/no-only-tests': ['error', {
      block: ['ava.default'],
      focus: ['only']
    }]
  }
```

Will now raise lint errors for code that looks like:

```js
ava.default.only(() => {})
```

Closes #14