### PR TITLE
Whitelist files for npm packaging, rather than using .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-.circleci/config.yml
-.prettierrc
-tests.js
-yarn.lock

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
   ],
   "author": "Levi Buzolic",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "rules/"
+  ],
   "scripts": {
     "test": "node tests.js"
   },


### PR DESCRIPTION
https://medium.com/@jdxcode/for-the-love-of-god-dont-use-npmignore-f93c08909d8d