### PR TITLE
Target node >=5 which supports the spread syntax which is used in the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint": ">=3.0.0"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=5.0.0"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
The spread syntax has been present in the package for ages, but `node 4 doesn't suppor tit. This updates the `engines` in the `package.json` to reflect that.