### PR TITLE
Match exact blocks by default, allow prefix matching with the use of a `*` in the block options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v3.0.0
+
+## Added
+
+ * Block scope matchers can accept a trailing `*` to optionally match blocks by prefix #35
+
+## Breaking
+
+ * Block matchers no longer match prefixes of blocks by default, can now be configured via options #35
+
 # v2.6.0
 
  * Disable auto fixing by default, allow it to be optionally enabled. #26

--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ This rule supports autofixing only when the `fix` option is set to `true` to avo
 
 Option | Type | Description
 ---|---|---
-`block` | `Array<string>` | Specify the block names that your testing framework uses.<br>Defaults to `["describe", "it", "context", "test", "tape", "fixture", "serial"]`
+`block` | `Array<string>` | Specify the block names that your testing framework uses. Add a `*` to the end of any string to enable prefix matching (ie. `test*` will match `testExample.only`)<br>Defaults to `["describe", "it", "context", "test", "tape", "fixture", "serial"]`
 `focus` | `Array<string>` | Specify the focus scope that your testing framework uses.<br>Defaults to `["only"]`
 `fix` | `boolean` | Enable this rule to auto-fix violations, useful for a pre-commit hook, not recommended for users with auto-fixing enabled in their editor.<br>Defaults to `false`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-no-only-tests",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "description": "ESLint rule for .only blocks in mocha tests",
   "keywords": [
     "eslint",

--- a/tests.js
+++ b/tests.js
@@ -12,6 +12,7 @@ ruleTester.run('no-only-tests', rules['no-only-tests'], {
     'xtape.only("A tape block", function() {});',
     'xtest.only("A test block", function() {});',
     'other.only("An other block", function() {});',
+    'testResource.only("A test resource block", function() {});',
     'var args = {only: "test"};',
     'it("should pass meta only through", function() {});',
     'obscureTestBlock.only("An obscure testing library test works unless options are supplied", function() {});',
@@ -150,6 +151,12 @@ ruleTester.run('no-only-tests', rules['no-only-tests'], {
       code: 'test.focus("An alternative focus function", function() {});',
       output: 'test("An alternative focus function", function() {});',
       errors: [{message: 'test.focus not permitted'}],
+    },
+    {
+      options: [{block: ['test*']}],
+      code: 'testResource.only("A test resource block", function() {});',
+      output: 'testResource.only("A test resource block", function() {});',
+      errors: [{message: 'testResource.only not permitted'}],
     },
   ],
 });


### PR DESCRIPTION
Previously blocks were matched by prefix, meaning `testResource.only` would trigger an error when trying to match for blocks of `test`. In coms cases this could be too noisy, especially when using libraries that may include a `.only` method as any of the default configured blocks (`'describe', 'it', 'context', 'test', 'tape', 'fixture', 'serial'`) could match.

This PR removes that behaviour by default and allows it to be optionally configured by specify blocks with a trailing asterisk (ie. `test*` to opt into the old behaviour).

Fixes #33 
