### PR TITLE
Update Actions for npm trusted publishing

### DIFF
--- a/.github/workflows/package-size-report.yml
+++ b/.github/workflows/package-size-report.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Package size report
         uses: pkg-size/action@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,11 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
@@ -26,9 +28,12 @@ jobs:
     name: Publish NPM
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
@@ -38,17 +43,15 @@ jobs:
       - name: Install dependencies
         run: bun ci
       - name: Publish package to NPM
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
+        run: npm publish --provenance
 
 #   publish-gpr:
 #     name: Publish GPR
 #     needs: test
 #     runs-on: ubuntu-latest
 #     steps:
-#       - uses: actions/checkout@v4
-#       - uses: actions/setup-node@v4
+#       - uses: actions/checkout@v6
+#       - uses: actions/setup-node@v6
 #         with:
 #           node-version: 24
 #           registry-url: https://npm.pkg.github.com/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,9 @@ jobs:
         node-version: [18, 20, 22, 24, 25]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Bun

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,9 +2,12 @@ Releasing is handled by GitHub Actions and is powered by GitHub Releases.
 
 1.  Set the new version following the [semver](https://semver.org/) specification in `package.json`
 2.  Verify the package contents and size using `bun pm pack --dry-run`
-3.  [Draft a new release](https://github.com/levibuzolic/eslint-plugin-no-only-tests/releases/new)
+3.  Ensure npm trusted publishing is configured for this package on npmjs.com
+    - Add a trusted publisher for `levibuzolic/eslint-plugin-no-only-tests`
+    - Select the `publish.yml` workflow in `.github/workflows`
+4.  [Draft a new release](https://github.com/levibuzolic/eslint-plugin-no-only-tests/releases/new)
     - Set the tag version to the new version
     - Set the release title to the new version
     - Auto-generate the release notes, excluding any internal changes
-4.  [Watch the release build](https://github.com/levibuzolic/eslint-plugin-no-only-tests/actions/workflows/publish.yml) and verify it completes successfully
-    - CI installs and validates with Bun, then publishes to npm using `npm publish`
+5.  [Watch the release build](https://github.com/levibuzolic/eslint-plugin-no-only-tests/actions/workflows/publish.yml) and verify it completes successfully
+    - CI installs and validates with Bun, then publishes to npm using GitHub OIDC trusted publishing

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Levi Buzolic",
   "repository": {
     "type": "git",
-    "url": "git@github.com:levibuzolic/eslint-plugin-no-only-tests.git"
+    "url": "git+https://github.com/levibuzolic/eslint-plugin-no-only-tests.git"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
## Summary
- Switch CI and release workflows to `actions/checkout@v6` and `actions/setup-node@v6` to avoid the Node 20 deprecation warnings.
- Move npm publishing to GitHub OIDC trusted publishing with `npm publish --provenance` and `id-token: write`.
- Normalize the repository URL in `package.json` and update release docs for the new publish flow.

## Testing
- Local workflow/config formatting checks passed.
- Existing unit and E2E test coverage remains in place and continues to validate the package before release.