### PR TITLE
Update release workflow for trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Switch the release workflow to run on `release.published`
- Update workflow actions to the current `v6` majors
- Remove token-based npm publishing in favor of GitHub OIDC trusted publishing
- Refresh release docs and normalize the repository URL for npm metadata

## Testing
- Not run (not requested)