### PR TITLE
Fix GitHub release npm publish auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
+          registry-url: https://registry.npmjs.org/
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.13

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
     name: Publish NPM
     needs: test
     runs-on: ubuntu-latest
+    environment: Publish
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- Restore `registry-url: https://registry.npmjs.org/` on the publish job's `actions/setup-node` step
- Keep the release workflow aligned with npm trusted publishing so `npm publish --provenance` can authenticate correctly

## Testing
- Not run (not requested)